### PR TITLE
Using keyFileVaultPass to decrypt encrypted vars/files when running playbook

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,17 +2,28 @@
 
 set -e
 
+# Evaluate keyfilevaultpass
+export KEYFILEVAULTPASS=
+if [ ! -z "$INPUT_KEYFILEVAULTPASS" ]
+then
+  echo "Using \$INPUT_KEYFILE_VAULT_PASS to decrypt and access vault."
+  mkdir -p ~/.ssh
+  echo "${INPUT_KEYFILEVAULTPASS}" > ~/.ssh/vault_key
+  export KEYFILEVAULTPASS="--vault-password-file ~/.ssh/vault_key"
+else
+  echo "\$INPUT_KEYFILEVAULTPASS not set. Won't be able to decrypt any encrypted file."
+fi
+
 # Evaluate keyfile
 export KEYFILE=
 if [ ! -z "$INPUT_KEYFILE" ]
 then
   echo "\$INPUT_KEYFILE is set. Will use ssh keyfile for host connections."
-  if [ ! -z "$INPUT_KEYFILEVAULTPASS" ]
+  if [ ! -z "$KEYFILEVAULTPASS" ]
   then
     echo "Using \$INPUT_KEYFILE_VAULT_PASS to decrypt keyfile."
     mkdir -p ~/.ssh
-    echo "${INPUT_KEYFILEVAULTPASS}" > ~/.ssh/vault_key
-    ansible-vault decrypt ${INPUT_KEYFILE} --vault-password-file ~/.ssh/vault_key
+    ansible-vault decrypt ${INPUT_KEYFILE} ${KEYFILEVAULTPASS}
   fi
   export KEYFILE="--key-file ${INPUT_KEYFILE}"
 else
@@ -88,5 +99,5 @@ else
 fi
 
 echo "going to execute: "
-echo ansible-playbook ${INPUT_PLAYBOOKNAME} ${INVENTORY} ${EXTRAFILE} ${INPUT_EXTRAVARS} ${KEYFILE} ${VERBOSITY}
-ansible-playbook ${INPUT_PLAYBOOKNAME} ${INVENTORY} ${EXTRAFILE} ${INPUT_EXTRAVARS} ${KEYFILE} ${VERBOSITY}
+echo ansible-playbook ${INPUT_PLAYBOOKNAME} ${INVENTORY} ${EXTRAFILE} ${INPUT_EXTRAVARS} ${KEYFILE} ${KEYFILEVAULTPASS} ${VERBOSITY}
+ansible-playbook ${INPUT_PLAYBOOKNAME} ${INVENTORY} ${EXTRAFILE} ${INPUT_EXTRAVARS} ${KEYFILE} ${KEYFILEVAULTPASS} ${VERBOSITY}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,6 @@ then
   if [ ! -z "$KEYFILEVAULTPASS" ]
   then
     echo "Using \$INPUT_KEYFILE_VAULT_PASS to decrypt keyfile."
-    mkdir -p ~/.ssh
     ansible-vault decrypt ${INPUT_KEYFILE} ${KEYFILEVAULTPASS}
   fi
   export KEYFILE="--key-file ${INPUT_KEYFILE}"


### PR DESCRIPTION
Wihtout passing vault password to the command, `ansible-playbook` is not able to run playbooks that require decrypted variable; and will throw the error below:
> ERROR! Attempting to decrypt but no vault secrets found
